### PR TITLE
Remove redundant `Arc` around reqwest client

### DIFF
--- a/rustique-cli/src/updater/update_manager.rs
+++ b/rustique-cli/src/updater/update_manager.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::sync::Arc;
 use std::time::Duration;
 use comfy_table::{Attribute, CellAlignment, Color};
 use comfy_table::presets::UTF8_HORIZONTAL_ONLY;
@@ -17,18 +16,16 @@ use crate::updater::self_update::RustiqueUpdater;
 const GITHUB_RUSTIQUE_URI: &str = "https://api.github.com/repos/Tekunogosu/Rustique/releases";
 
 pub struct GithubApi {
-    agent: Arc<reqwest::Client>,
+    agent: reqwest::Client,
 }
 
 impl GithubApi {
     pub fn new() -> Self {
         Self {
-            agent: Arc::new(
-                Client::builder()
+            agent: Client::builder()
                 .timeout(Duration::from_secs(20))
                 .user_agent(RUSTIQUE_USER_AGENT)
                 .build().expect("Failed to build Github API client")
-            )
         }
     }
 

--- a/rustique-core/src/api/client.rs
+++ b/rustique-core/src/api/client.rs
@@ -5,7 +5,6 @@ use crate::consts::FILE_MODINFO_JSON;
 use owo_colors::OwoColorize;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
-use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, info};
 use std::fmt::Write;
@@ -24,7 +23,7 @@ pub const RUSTIQUE_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!(
 
 #[derive(Debug, Clone)]
 pub struct ApiClient {
-    agent: Arc<reqwest::Client>,
+    agent: reqwest::Client,
 }
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -66,17 +65,15 @@ pub enum VSWinInstallerType {
 impl ApiClient {
     pub fn new() -> Self {
         Self {
-            agent: Arc::new(
-                reqwest::Client::builder()
-                    .timeout(Duration::from_secs(20))
-                    .user_agent(RUSTIQUE_USER_AGENT)
-                    .build()
-                    .expect("Failed to build HTTP client")
-            ),
+            agent: reqwest::Client::builder()
+                .timeout(Duration::from_secs(20))
+                .user_agent(RUSTIQUE_USER_AGENT)
+                .build()
+                .expect("Failed to build HTTP client"),
         }
     }
 
-    pub fn _with_agent(agent: Arc<reqwest::Client>) -> Self {
+    pub fn _with_agent(agent: reqwest::Client) -> Self {
         Self { agent }
     }
 


### PR DESCRIPTION
`Arc` is used in `reqwest::Client` internally which makes wrapping it redundant.