### PR TITLE
refactor(core.api.client): log `fetch_mod` errors w/ `error`

### DIFF
--- a/rustique-core/src/api/client.rs
+++ b/rustique-core/src/api/client.rs
@@ -186,7 +186,7 @@ impl ApiClient {
                         Some((mod_id, the_mod))
                     },
                     Err(e) => {
-                        info!("{mod_id} {e}");
+                        error!("{mod_id} {e}");
                         pb_clone.set_message(format!("Failed: {}", mod_id.red()));
                         pb_clone.inc(1);
                         None


### PR DESCRIPTION
Fixes #48  
See [https://asciinema.org/a/w1SbEf9jRr0M7fIu](https://asciinema.org/a/w1SbEf9jRr0M7fIu)

Known issues:

*   Mods that are unavailable from VS ModDB will produce ``missing field `modid` `` errors. This can be \_very\_ noisy.
    *   In my mod list, this includes `entitycolortint`, `entityemotelib`, `panduhsnewpatches`, `wflavornotifications`

```powershell
	⠴ [00:00:00] [▒░░░░░░░░░░░░░░░░░░░] 10/691 iniidae                                                                                                                                                                                          2026-03-23T07:01:59.601136Z ERROR tokio-rt-worker ThreadId(16) wflavornotifications missing field `mod` at line 1 column 20
⠁ [00:00:01] [█▒░░░░░░░░░░░░░░░░░░] 58/691 polylocusts                                                                                                                                                                                      2026-03-23T07:02:00.027277Z ERROR tokio-rt-worker ThreadId(16) panduhsnewpatches missing field `mod` at line 1 column 20
⠤ [00:00:05] [███████████████▒░░░░] 536/691 climbmountain                                                                                                                                                                                   2026-03-23T07:02:04.529595Z ERROR tokio-rt-worker ThreadId(16) entitycolortint missing field `mod` at line 1 column 20
⠂ [00:00:07] [███████████████████▒] 674/691 newkoboldafeffe                                                                                                                                                                                 2026-03-23T07:02:05.930165Z ERROR tokio-rt-worker ThreadId(14) entityemotelib missing field `mod` at line 1 column 20
  [00:00:07] [████████████████████] 691/691 Fetch Complete                                                                                                                                                                                  ╭────────────────────────────────────╮
```