### PR TITLE
fix(core.api.api_structs): filter `null` from `ApiModJson.tags`

### DIFF
--- a/rustique-core/src/api/api_structs.rs
+++ b/rustique-core/src/api/api_structs.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::path::PathBuf;
@@ -54,6 +54,17 @@ impl Display for StringOrBool {
         };
         write!(f, "{str}")
     }
+}
+
+fn some_array_items<'de, D>(d: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Deserialize::deserialize(d).map(|x: Vec<Option<String>>| {
+        x.iter()
+            .filter_map(|y: &Option<String>| y.is_some().then(|| y.clone().unwrap_or_default()))
+            .collect()
+    })
 }
 
 // Due to mod authors not following the modinfo.json spec for mods, we have to
@@ -310,7 +321,7 @@ pub struct ApiModJson {
     pub last_released: Option<String>,
     #[serde(default, rename = "lastmodified",skip_serializing_if = "Option::is_none")]
     pub last_modified: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with="some_array_items")]
     pub tags: Vec<String>,
     #[serde(default)]
     pub releases: Vec<Release>,


### PR DESCRIPTION
This adds a custom deserializer to filter the `null` out of `tags: (string|null)[]` parsed from a `fetch_mod` HTTP response.

Fixes #49

These two merge requests are my foray into writing Rust. So, I will be very thankful for feedback!

---

For context...
```pwsh
$ curl -s https://mods.vintagestory.at/api/mod/altarmor | pcregrep -oe '"tags":\\[["a-zA-Z,]+null["a-zA-Z, ]*\\]'
"tags":["Cosmetics",null,"Tweak","Clothing","armor"]

$ rustique -d sync &> .rustique.log

$ grep 'invalid type: null, expected a string' .rustique.log
2026-03-23T05:36:34.790071Z  INFO tokio-runtime-worker ThreadId(19) fahussar invalid type: null, expected a string at line 1 column 25152
2026-03-23T05:36:34.952832Z  INFO tokio-runtime-worker ThreadId(06) xskillsgilded invalid type: null, expected a string at line 1 column 22565
2026-03-23T05:36:35.303648Z  INFO tokio-runtime-worker ThreadId(14) sconce invalid type: null, expected a string at line 1 column 3767
2026-03-23T05:36:35.537223Z  INFO tokio-runtime-worker ThreadId(16) canjewelry invalid type: null, expected a string at line 1 column 4150
2026-03-23T05:36:35.710086Z  INFO tokio-runtime-worker ThreadId(14) mobsradar invalid type: null, expected a string at line 1 column 10318
2026-03-23T05:36:35.712302Z  INFO tokio-runtime-worker ThreadId(16) altarmor invalid type: null, expected a string at line 1 column 12032
2026-03-23T05:36:35.787650Z  INFO tokio-runtime-worker ThreadId(10) charlottesclothes invalid type: null, expected a string at line 1 column 1733
2026-03-23T05:36:36.208616Z  INFO tokio-runtime-worker ThreadId(03) vintagegoat invalid type: null, expected a string at line 1 column 2144
2026-03-23T05:36:36.211272Z  INFO tokio-runtime-worker ThreadId(19) fantasycreaturesupdate invalid type: null, expected a string at line 1 column 5940
2026-03-23T05:36:36.609919Z  INFO tokio-runtime-worker ThreadId(15) fatemplar invalid type: null, expected a string at line 1 column 27676
2026-03-23T05:36:36.727849Z  INFO tokio-runtime-worker ThreadId(14) faviking invalid type: null, expected a string at line 1 column 21438
2026-03-23T05:36:36.742517Z  INFO tokio-runtime-worker ThreadId(15) vanvar invalid type: null, expected a string at line 1 column 10851
2026-03-23T05:36:37.617775Z  INFO tokio-runtime-worker ThreadId(10) vintageskavenrat invalid type: null, expected a string at line 1 column 5563
2026-03-23T05:36:37.912617Z  INFO tokio-runtime-worker ThreadId(15) fagothic invalid type: null, expected a string at line 1 column 25830
2026-03-23T05:36:37.957469Z  INFO tokio-runtime-worker ThreadId(16) draconis invalid type: null, expected a string at line 1 column 12163
2026-03-23T05:36:38.254255Z  INFO tokio-runtime-worker ThreadId(15) sirenia invalid type: null, expected a string at line 1 column 9669
2026-03-23T05:36:38.939773Z  INFO tokio-runtime-worker ThreadId(16) fishing invalid type: null, expected a string at line 1 column 1721
2026-03-23T05:36:39.463540Z  INFO tokio-runtime-worker ThreadId(06) fadynasties invalid type: null, expected a string at line 1 column 24196
2026-03-23T05:36:40.777716Z  INFO tokio-runtime-worker ThreadId(10) ohaa invalid type: null, expected a string at line 1 column 2680
2026-03-23T05:36:40.992875Z  INFO tokio-runtime-worker ThreadId(03) maltiezswords invalid type: null, expected a string at line 1 column 805
2026-03-23T05:36:41.289563Z  INFO tokio-runtime-worker ThreadId(04) danatweaks invalid type: null, expected a string at line 1 column 17402
```