### PR TITLE
fix(core.api.client): aggregate fetch_all_mods errors

### DIFF
--- a/rustique-core/src/api/client.rs
+++ b/rustique-core/src/api/client.rs
@@ -169,8 +169,7 @@ impl ApiClient {
         pb.set_message("Fetching mods...");
 
         // Create a vector to hold all our task handles
-        let mut tasks: Vec<JoinHandle<Option<(ModID, Mod)>>> = Vec::with_capacity(valid_ids.len());
-
+        let mut tasks: Vec<JoinHandle<Result<(ModID, Mod), String>>> = Vec::with_capacity(valid_ids.len());
         // Spawn a task for each mod
         for (i, mod_id) in valid_ids.into_iter().enumerate() {
             info!("ModID: {}", mod_id);
@@ -183,13 +182,15 @@ impl ApiClient {
                     Ok(the_mod) => {
                         pb_clone.set_message(mod_id.to_string());
                         pb_clone.inc(1);
-                        Some((mod_id, the_mod))
+                        Ok((mod_id, the_mod))
                     },
                     Err(e) => {
-                        error!("{mod_id} {e}");
-                        pb_clone.set_message(format!("Failed: {}", mod_id.red()));
                         pb_clone.inc(1);
-                        None
+                        Err(format!(
+                            "Failed: {0}\nError:\n{1}\n",
+                            &mod_id.red(),
+                            &e.to_string().red()
+                        ))
                     }
                 }
             });
@@ -205,12 +206,23 @@ impl ApiClient {
         let results_vec = join_all(tasks).await;
         // Wait for all tasks to complete and collect results
         let mut results = HashMap::new();
-        for (mod_id, mod_info) in results_vec.into_iter().flatten().flatten() {
-            // Handle any JoinError from the task itself
-            results.insert(mod_id, mod_info);
+        let mut error_messages: Vec<String> = Vec::with_capacity(results_vec.len());
+        for result in results_vec.into_iter().flatten() {
+            match result {
+                Ok((mod_id, mod_info)) => {
+                    // Handle any JoinError from the task itself
+                    results.insert(mod_id, mod_info);
+                }
+                Err(error_message) => {
+                    error_messages.push(error_message);
+                }
+            }
         }
 
         pb.finish_with_message("Fetch Complete");
+        for err in error_messages.iter() {
+            error!(err)
+        }
         Ok(results)
     }
 

--- a/rustique-core/src/api/client.rs
+++ b/rustique-core/src/api/client.rs
@@ -221,7 +221,7 @@ impl ApiClient {
 
         pb.finish_with_message("Fetch Complete");
         for err in error_messages.iter() {
-            error!(err)
+            error!("{}", err);
         }
         Ok(results)
     }


### PR DESCRIPTION
Because this solution wraps a `Result` with another `Result`, it increases complexity a bit. But this is more acceptable than alternatives such as...
- Change the return type of `ApiClient.fetch_mod` to accommodate a String-type alternative result. `fetch_mod` would never use this alternative return type; only callers would use it. This breaking change had insufficient justification.
- Store error messages in a `Mutex<Vec<String>>`. Each task would use `i` to index into their own, exclusive entries in the vector. However, the compiler was not satisfied by the way I wanted to do it. I could have added a thread-safe Vector dependency or implemented a message queue, but both were big changes for what seemed like a small problem.

Fixes #54 "Errors in `fetch_all_mods` interrupt the progress bar"

---

Example Output:

```pwsh
> rustique sync
╭─────────────────────────────────────────────────────────────────────────╮
  Syncing...   /home/noah/Games/VintageStory/VSInstallations/latest/Mods/
╰─────────────────────────────────────────────────────────────────────────╯
  [00:00:04] [████████████████████] 396/396 Fetch Complete                                                          2026-04-18T01:09:35.612905Z ERROR main ThreadId(01) err="Failed: \u{1b}[31mentityemotelib\u{1b}[39m\nError:\n\u{1b}[31mmissing field `mod` at line 1 column 20\u{1b}[39m\n"
2026-04-18T01:09:35.612921Z ERROR main ThreadId(01) err="Failed: \u{1b}[31mentitycolortint\u{1b}[39m\nError:\n\u{1b}[31mmissing field `mod` at line 1 column 20\u{1b}[39m\n"
╭────────────────────────────────────╮
  Sync operation completed:    5.26s
╰────────────────────────────────────╯
```